### PR TITLE
Add extrapolate option to polynomial regression.

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -47,8 +47,9 @@
                     regression = _exponential(s.data) 
                 }                                
                 else if (regressionType == "polynomial"){  
-	                var order = s.regressionSettings.order || 2
-                    regression = _polynomial(s.data, order) ;                    
+                    var order = s.regressionSettings.order || 2;
+                    var extrapolate = s.regressionSettings.extrapolate || 0;
+                    regression = _polynomial(s.data, order, extrapolate) ;                    
                 }else if (regressionType == "logarithmic"){
                     regression = _logarithmic(s.data) ;
                 }else if (regressionType == "loess"){
@@ -260,7 +261,7 @@
     /**
      * Code extracted from https://github.com/Tom-Alexander/regression-js/
      */
-    function _polynomial(data, order) {
+    function _polynomial(data, order, extrapolate) {
         if(typeof order == 'undefined'){
             order =2;
         }
@@ -292,12 +293,20 @@
 
         var equation = gaussianElimination(rhs, k);
 
-        for (var i = 0, len = data.length; i < len; i++) {
-            var answer = 0;
-            for (var w = 0; w < equation.length; w++) {
-                answer += equation[w] * Math.pow(data[i][0], w);
+        var resultLength = data.length + extrapolate;
+        var step = data[data.length - 1][0] - data[data.length - 2][0];
+        for (var i = 0, len = resultLength; i < len; i++) {
+            var answer = 0;            
+            if(typeof data[i] !== 'undefined') {
+                var x = data[i][0];
+            } else {
+                var x = data[data.length - 1][0] + (i - data.length) * step;    
             }
-            results.push([data[i][0], answer]);
+
+            for (var w = 0; w < equation.length; w++) {
+                answer += equation[w] * Math.pow(x, w);
+            }
+            results.push([x, answer]);
         }
 
         results.sort(function(a,b){


### PR DESCRIPTION
*Alright here is the fixed version.* This change-set introduces an `extrapolate` option to polynomial regression line. It assumes the change between last two entries of the actual data array is the step size the extrapolation should sample with. Using that, it continues plotting values until `extrapolate=N` values got pushed. What do you think?