### PR TITLE
Added the possibility to set a regression series ID.

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -34,6 +34,7 @@
                         visible: s.regressionSettings.visible,
                         type: s.regressionSettings.linetype || 'spline',
                         name: s.regressionSettings.name || "Equation: %eq", 
+                        id: s.regressionSettings.id,
                         color: s.regressionSettings.color || '',
                         dashStyle: s.regressionSettings.dashStyle || 'solid',
                         tooltip:{ 


### PR DESCRIPTION
If you add an ID in regression settings it is now recorded by highcharts. 
This means that you can, for example, use chart.get(id) in order to hide
or show a regression line programmatically.