### PR TITLE
Fixed - Uncaught SyntaxError: Unexpected token var

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -313,7 +313,7 @@
         var resultLength = data.length + extrapolate;
         var step = data[data.length - 1][0] - data[data.length - 2][0];
         for (var i = 0, len = resultLength; i < len; i++) {
-            var answer = 0,
+            var answer = 0;
             var x = 0;
             if(typeof data[i] !== 'undefined') {
                 x = data[i][0];


### PR DESCRIPTION
Hello.

This fixes a `Uncaught SyntaxError: Unexpected token var` which occurs when using the `_polynomial` function. This issue was introduced in #57 

Thank you.