### PR TITLE
Support modules

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -1,4 +1,12 @@
-(function (H) {
+(function (factory) {
+    "use strict";
+
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory;
+    } else {
+        factory(Highcharts);
+    }
+}(function (H) {
     var processSerie = function (s, method, chart) {
         if (s.regression && !s.rendered) {
             s.regressionSettings = s.regressionSettings || {};
@@ -559,6 +567,4 @@
 
         return SE;
     }
-
-
-}(Highcharts));
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "highcharts-regression",
+  "version": "1.0.5",
+  "description": "This allows you to add regression lines to any series. Supports: linear, polynomial, logarithmic, exponential and loess. Calculates the r-value",
+  "main": "highcharts-regression.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phpepe/highcharts-regression.git"
+  },
+  "keywords": [
+    "highcharts",
+    "regression",
+    "trendline",
+    "loess fitline"
+  ],
+  "author": {
+    "name": "Ignacio Vazquez",
+    "url": "https://github.com/phpepe/"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/phpepe/highcharts-regression/issues"
+  },
+  "homepage": "https://github.com/phpepe/highcharts-regression#readme"
+}


### PR DESCRIPTION
I added a `package.json` to allow installing this plugin with NPM. I mostly copied what was in the `manifest.json`. I'll leave it up to you if you want to actually publish the package on NPM. It should fix #56.

Usage is as follow:
```
var Highcharts = require('highcharts/highcharts');
require('highcharts-regression')(Highcharts);
```

It match how [Highchart and other plugins are loaded](https://github.com/highcharts/highcharts-dist#load-highcharts-as-a-commonjs-module). 