### PR TITLE
Error when having multiple line charts #71 #66

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -88,22 +88,24 @@
     H.wrap(H.Chart.prototype, 'init', function (proceed) {
         var series = arguments[1].series;
         var extraSeries = [];
-        var i = 0;
-        for (i = 0; i < series.length; i++) {
-            var s = series[i];
-            var extraSerie = processSerie(s, 'init', this);
-            extraSeries.push(extraSerie);
+        for (var i = 0; i < series.length; i++) {
+
+            var extraSerie = processSerie(series[i], 'init', this);
             arguments[1].series[i].rendered = true;
+
+            if (extraSerie) {
+                extraSeries.push(extraSerie);
+            }
         }
 
-        if (extraSerie) {
+        if (series && extraSeries.length > 0) {
             arguments[1].series = series.concat(extraSeries);
         }
 
         proceed.apply(this, Array.prototype.slice.call(arguments, 1));
 
-
     });
+
 
     H.wrap(H.Chart.prototype, 'addSeries', function (proceed) {
         var s = arguments[1];


### PR DESCRIPTION
Error when having multiple line charts with ON and OFF Regression
I found a problem when adding more then one series to the regression library, I need to have all ON to have regression and cannot be selective regarding which one I would like to have a regression line.
I made a few changes to prevent adding undefined series in the case of regression being OFF and when the last series was undefined the validation seemed to not address this issue, so, I changed it as well (concat). With this I can now have a mix of series with regression ON and OFF without any problem.

check issue 
https://github.com/streamlinesocial/highcharts-regression/issues/71
