### PR TITLE
Make highcharts-regression compatible with highcharts >= v6.1.2

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -1,11 +1,23 @@
-﻿(function (factory) {
-    "use strict";
-
-    if (typeof module === "object" && module.exports) {
+﻿(function(factory) {
+	"use strict";
+	
+	if (typeof module === "object" && module.exports) {
         module.exports = factory;
     } else {
-        factory(Highcharts);
-    }
+		if(typeof define === "function" && define.amd){
+			define(function() {
+				return factory
+			});
+		}
+		else{
+			if(typeof Highcharts !== "undefined"){
+				factory(Highcharts);
+			}
+			else{
+				void 0;
+			}
+		}
+    }	
 }(function (H) {
     var processSerie = function (s, method, chart) {
         if (s.regression && !s.rendered) {


### PR DESCRIPTION
Fix "Highcharts is not defined" issue with highcharts >= 6.1.2
Tested with angularJs on Highcharts  6.1.2 and 7.0.1 