### PR TITLE
add null check for when there are no series

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -96,12 +96,14 @@
         var series = arguments[1].series;
         var extraSeries = [];
         var i = 0;
-        for (i = 0; i < series.length; i++) {
-            var s = series[i];
-            if (s.regression) {
-                var extraSerie = processSerie(s, 'init', this);
-                extraSeries.push(extraSerie);
-                arguments[1].series[i].rendered = true;
+        if (series) {
+            for (i = 0; i < series.length; i++) {
+                var s = series[i];
+                if (s.regression) {
+                    var extraSerie = processSerie(s, 'init', this);
+                    extraSeries.push(extraSerie);
+                    arguments[1].series[i].rendered = true;
+                }
             }
         }
 


### PR DESCRIPTION
Charts can be initialized without a series, and many times the series come from async data that may not exist at the time of loading. Although the series may eventually exist when the async request is fulfilled, the current implementation for this regressions requires initializing the chart with a blank `series: []` each time or it will break. 