### PR TITLE
Added posibility to change 'label' settings for regression line

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -39,6 +39,7 @@
                 visible: s.regressionSettings.visible,
                 type: s.regressionSettings.linetype || 'spline',
                 name: s.regressionSettings.name || "Equation: %eq",
+                label: s.regressionSettings.label || {},
                 id: s.regressionSettings.id,
                 dashStyle: s.regressionSettings.dashStyle || 'solid',
                 showInLegend: !s.regressionSettings.hideInLegend,


### PR DESCRIPTION
'label' setting possibility was missing so i added it in case if anyone would not want text to be displayed below the line (just like me)