### PR TITLE
Added dataLabel handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ The sequential index of the series in the legend. Default: `undefined`
 ##### `tooltip` (Object)
 Stardard Highcharts [tooltip object](http://api.highcharts.com/highcharts/tooltip)
 
+##### `dataLabels` (Array of objects)
+Show dataLabels on specified points. Choose which points should have labels and enter their format. Supports Highchart [dataLabel.format](https://api.highcharts.com/highcharts/plotOptions.series.dataLabels.format) and the regression variables stated for [name](#name-string). Default: `undefined`
+
+Format expected for dataLabel objects:
+```
+{
+  pointIndex: number // Index of the point to add label to.
+  format: string // The text/format for the label.
+}
+```
+
 ### Exposed properties:
 The plugin exposes properties to `series[regressionSeries].options.regressionOutputs (Object)`
 * `equation` (Array[Int]) individual parts of the regression equation

--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -94,17 +94,29 @@
             regression.rSquared = _round(regression.rSquared, s.regressionSettings.decimalPlaces);
             regression.standardError = _round(standardError(mergedData, regression.points), s.regressionSettings.decimalPlaces);
             extraSerie.data = regression.points;
-            extraSerie.name = extraSerie.name.replace("%r2", regression.rSquared);
-            extraSerie.name = extraSerie.name.replace("%r", regression.rValue);
-            extraSerie.name = extraSerie.name.replace("%eq", regression.string);
-            extraSerie.name = extraSerie.name.replace("%se", regression.standardError);
+            extraSerie.name = replaceRegressionPlaceholders(extraSerie.name, regression);
 
-            if (extraSerie.visible === false) {
-                extraSerie.visible = false;
+            if (s.regressionSettings.dataLabels !== undefined) {
+                for (let i = 0; i < s.regressionSettings.dataLabels.length; i++) {
+                    var dataLabel = s.regressionSettings.dataLabels[i]
+                    var dataLabelPoint = extraSerie.data[dataLabel.pointIndex];
+                    var dataLabelFormat = replaceRegressionPlaceholders(dataLabel.format, regression);
+
+                    if (dataLabelPoint !== undefined) {
+                        extraSerie.data[dataLabel.pointIndex] = {
+                            x: dataLabelPoint[0],
+                            y: dataLabelPoint[1],
+                            dataLabels: {
+                                enabled: true,
+                                format: dataLabelFormat
+                            }
+                        };
+                    }
+                }
             }
+
             extraSerie.regressionOutputs = regression;
             return extraSerie;
-
         }
     }
 
@@ -640,5 +652,12 @@
     function _round(number, decimalPlaces) {
         var decimalFactor = Math.pow(10, decimalPlaces);
         return Math.round(number * decimalFactor) / decimalFactor;
+    }
+    function replaceRegressionPlaceholders(text, regression) {
+        return text
+            .replace("%r2", regression.rSquared)
+            .replace("%r", regression.rValue)
+            .replace("%eq", regression.string)
+            .replace("%se", regression.standardError);
     }
 }));


### PR DESCRIPTION
Added ability to add `dataLabels` to specific points on the regression line. It can be used on all points like on original Highcharts series, or on single points to for example display regression variables on the beginning or end of the line like this: 
![image](https://user-images.githubusercontent.com/5909082/86917292-22cc8180-c125-11ea-9e18-b19aa463e59c.png)
